### PR TITLE
Add support for txt-records in service definition

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -133,6 +133,13 @@ avahi_services:
   #   type: _ssh._tcp
   #   port: 22
   #   state: absent
+  # adisk:
+  #   type: _adisk._tcp
+  #   port: 9
+  #   txt:
+  #     - dk0=adVN=backups,adVF=0x82
+  #     - sys=adVF=0x100
+  #   state: present
 
 avahi_use_ipv4: true
 

--- a/templates/etc/avahi/services/avahi.service.j2
+++ b/templates/etc/avahi/services/avahi.service.j2
@@ -9,5 +9,10 @@
     <subtype>{{ item['value']['subtype'] }}</subtype>
 {%     endif %}
     <port>{{ item['value']['port'] }}</port>
+{%     if item['value']['txt'] is defined %}
+{%       for txtRecord in item['value']['txt'] %}
+    <txt-record>{{ txtRecord }}</txt-record>
+{%       endfor %}
+{%     endif %}
   </service>
 </service-group>


### PR DESCRIPTION
Add missing support for txt-records in service definition

## Description
The objects in `avahi_services` can now contain an entry `txt` which is a list of strings.  
Each list entry will result in a single <txt-record> line in the service definition file.

## Related Issue
closes #3 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
